### PR TITLE
Refactor theme mode switch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+.now

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,52 +1,7 @@
-import { useEffect, useState } from 'react';
-import { ThemeObject } from '../interfaces';
-
-const themes = {
-  dark: {
-    primary: '#1ca086',
-    textColor: 'white',
-    backgroundColor: '#1d3a48',
-    secondaryBackgroundColor: '#0d1219',
-    blockquoteColor: 'rgba(255,255,255,0.20)',
-    icon: 'white'
-  },
-  light: {
-    primary: '#1ca086',
-    textColor: 'black',
-    backgroundColor: '#cbdde4',
-    secondaryBackgroundColor: '#EDF2F7',
-    blockquoteColor: 'rgba(0,0,0,0.80)',
-    icon: '#0d1219'
-  }
-};
-
-const setCSSVariables = (properties: ThemeObject) => {
-  for (const property in properties) {
-    document.documentElement.style.setProperty(`--${property}`, properties[property]);
-  }
-};
+import { useTheme } from '../context/Theme';
 
 const ThemeToggle = () => {
-  const [theme, setTheme] = useState<'dark' | 'light'>('dark');
-
-  useEffect(() => {
-    const previouslySelectedTheme = localStorage.getItem('theme');
-
-    // only update the theme if light theme was previously selected
-    if (previouslySelectedTheme === 'light') {
-      setTheme(previouslySelectedTheme);
-    }
-  }, []);
-
-  useEffect(() => {
-    // remember the previous theme when the user visits the site
-    localStorage.setItem('theme', theme);
-
-    // set the custom properties for use in styles
-    setCSSVariables(themes[theme]);
-  }, [theme]);
-
-  const toggleTheme = () => setTheme(theme === 'light' ? 'dark' : 'light');
+  const { theme, toggleTheme } = useTheme();
 
   return (
     <label className="theme-switch">

--- a/src/context/Theme.tsx
+++ b/src/context/Theme.tsx
@@ -1,22 +1,66 @@
-import { createContext, ReactChild, ReactElement, useContext, useMemo, useState } from 'react';
+import { createContext, ReactNode, useContext, useLayoutEffect, useMemo, useState } from 'react';
+import { Theme, ThemeContextType, ThemeObject } from '../types';
 
-const ThemeContext = createContext({ theme: 'dark', toggleTheme: () => {} });
+const themes = {
+  dark: {
+    primary: '#1ca086',
+    textColor: 'white',
+    backgroundColor: '#1d3a48',
+    secondaryBackgroundColor: '#0d1219',
+    blockquoteColor: 'rgba(255,255,255,0.20)',
+    icon: 'white'
+  },
+  light: {
+    primary: '#1ca086',
+    textColor: 'black',
+    backgroundColor: '#cbdde4',
+    secondaryBackgroundColor: '#EDF2F7',
+    blockquoteColor: 'rgba(0,0,0,0.80)',
+    icon: '#0d1219'
+  }
+};
 
-export default function ThemeProvider({ children }: { children: ReactChild }): ReactElement {
-  const [theme, setTheme] = useState('dark');
+const setCSSVariables = (properties: ThemeObject) => {
+  for (const property in properties) {
+    document.documentElement.style.setProperty(`--${property}`, properties[property]);
+  }
+};
 
-  const toggleTheme = (): void => {
-    if (theme === 'dark') {
-      setTheme('light');
+const ThemeContext = createContext<ThemeContextType>({ theme: 'dark', toggleTheme: () => {} });
+
+export const ThemeProvider = ({ children }: { children: ReactNode }) => {
+  const [theme, setTheme] = useState<Theme>(null);
+
+  useLayoutEffect(() => {
+    const previouslySelectedTheme = localStorage.getItem('theme') as Theme;
+
+    // use the previously selected theme and default to light if none was selected
+    if (previouslySelectedTheme) {
+      setTheme(previouslySelectedTheme);
     } else {
-      setTheme('dark');
+      setTheme('light');
     }
+  }, []);
+
+  useLayoutEffect(() => {
+    if (theme) {
+      // set the custom properties for use in styles
+      setCSSVariables(themes[theme]);
+    }
+  }, [theme]);
+
+  const toggleTheme = () => {
+    const selectedTheme = theme === 'light' ? 'dark' : 'light';
+    setTheme(selectedTheme);
+    localStorage.setItem('theme', selectedTheme);
   };
 
   const themeValue = useMemo(() => ({ theme, toggleTheme }), [theme, toggleTheme]);
 
+  if (theme === null) return null;
+
   return <ThemeContext.Provider value={themeValue}>{children}</ThemeContext.Provider>;
-}
+};
 
 export const useTheme = () => {
   const context = useContext(ThemeContext);

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -1,3 +1,0 @@
-export interface ThemeObject {
-  [key: string]: string;
-}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,17 +1,20 @@
 import { AppProps } from 'next/app';
 import Head from 'next/head';
 import Layout from '../components/layout';
+import { ThemeProvider } from '../context/Theme';
 import '../styles/index.css';
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (
-    <Layout>
+    <ThemeProvider>
       <Head>
         <title>FrontendTony</title>
         <link rel="icon" href="/favicon.ico" />
       </Head>
-      <Component {...pageProps} />
-    </Layout>
+      <Layout>
+        <Component {...pageProps} />
+      </Layout>
+    </ThemeProvider>
   );
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,10 @@
+export interface ThemeObject {
+  [key: string]: string;
+}
+
+export type Theme = 'light' | 'dark' | null;
+
+export interface ThemeContextType {
+  theme: Theme;
+  toggleTheme: () => void;
+}


### PR DESCRIPTION
This PR fixes the subtle ui bug that shows a momentary flash of the app before switching to the previously selected theme

The solution was to move the theme logic to a context that wraps the entire application and set the theme before the browser gets to paint anything on the screen